### PR TITLE
マーケットをDBに保存、一覧取得 + a

### DIFF
--- a/ui/.babelrc
+++ b/ui/.babelrc
@@ -1,6 +1,4 @@
 {
   "presets": ["next/babel"],
-  "plugins": [
-    "superjson-next"
-  ]
+  "plugins": ["superjson-next"]
 }

--- a/ui/prisma/migrations/20220401012854_/migration.sql
+++ b/ui/prisma/migrations/20220401012854_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `contract` to the `Market` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Market" ADD COLUMN     "contract" VARCHAR(100) NOT NULL;

--- a/ui/prisma/schema.prisma
+++ b/ui/prisma/schema.prisma
@@ -13,6 +13,7 @@ datasource db {
 model Market {
   id        String   @id @default(cuid())
   title     String   @db.VarChar(100)
+  contract  String   @db.VarChar(100)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }

--- a/ui/prisma/seed.ts
+++ b/ui/prisma/seed.ts
@@ -3,9 +3,9 @@ import { prisma } from '../src/lib/prisma'
 const main = async () => {
   await prisma.market.createMany({
     data: [
-      { title: 'sample market 1' },
-      { title: 'sample market 2' },
-      { title: 'sample market 3' },
+      { title: 'sample market 1', contract: '0x01' },
+      { title: 'sample market 2', contract: '0x02' },
+      { title: 'sample market 3', contract: '0x03' },
     ],
   })
 }

--- a/ui/src/components/AppHeader/AppHeader.tsx
+++ b/ui/src/components/AppHeader/AppHeader.tsx
@@ -5,8 +5,8 @@ import WalletButton from '~/components/WalletButton'
 
 const AppHeader: VFC = () => {
   return (
-    <div className="relative bg-white border-b">
-      <div className="flex items-center container mx-auto py-6 px-8">
+    <div className="relative max-w-5xl mx-auto bg-white">
+      <div className="flex items-center container mx-auto py-6 px-2">
         <Link href="/">
           <a className="text-2xl font-bold">DEMO</a>
         </Link>

--- a/ui/src/components/AppHeader/AppHeader.tsx
+++ b/ui/src/components/AppHeader/AppHeader.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { VFC } from 'react'
 
 import WalletButton from '~/components/WalletButton'
@@ -6,7 +7,9 @@ const AppHeader: VFC = () => {
   return (
     <div className="relative bg-white border-b">
       <div className="flex items-center container mx-auto py-6 px-8">
-        <div className="text-2xl font-bold">DEMO</div>
+        <Link href="/">
+          <a className="text-2xl font-bold">DEMO</a>
+        </Link>
         <span className="ml-auto">
           <WalletButton />
         </span>

--- a/ui/src/components/AppHero/AppHero.tsx
+++ b/ui/src/components/AppHero/AppHero.tsx
@@ -1,42 +1,42 @@
 import { VFC } from 'react'
 
-
 const AppHero: VFC = () => {
   return (
-      <div className="bg-gray-800">
-        <div className="sm:blocksm:inset-0">
-          <div className="py-24 flex flex-col items-center justify-center">
-            <h1 className="font-bold text-4xl text-white">
-              Bet on your Beliefs
-            </h1>
-            <div className="mt-4 text-lg text-gray-400 text-center">
-              <p>Demo is a decentralized information markets platform, </p>
-              <p>
-                harnessing the power of free markets to demystify the real world
-                events that matter most to you.
-              </p>
-            </div>
-            <div className="max-w-2xl mt-12 text-sm alert shadow-lg">
-              <div>
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  className="stroke-info flex-shrink-0 w-6 h-6"
-                >
-                  <path
-                    strokeLinecap='round'
-                    strokeLinejoin='round'
-                    strokeWidth={2}
-                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                  ></path>
-                </svg>
-                <span>The markets listed here are for informational purposes only. We take no profits from them.</span>
-              </div>
+    <div className="bg-gray-800">
+      <div className="sm:blocksm:inset-0">
+        <div className="py-24 flex flex-col items-center justify-center">
+          <h1 className="font-bold text-4xl text-white">Bet on your Beliefs</h1>
+          <div className="mt-4 text-lg text-gray-400 text-center">
+            <p>Demo is a decentralized information markets platform, </p>
+            <p>
+              harnessing the power of free markets to demystify the real world
+              events that matter most to you.
+            </p>
+          </div>
+          <div className="max-w-2xl mt-12 text-sm alert shadow-lg">
+            <div>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                className="stroke-info flex-shrink-0 w-6 h-6"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                ></path>
+              </svg>
+              <span>
+                The markets listed here are for informational purposes only. We
+                take no profits from them.
+              </span>
             </div>
           </div>
         </div>
       </div>
+    </div>
   )
 }
 

--- a/ui/src/components/AppHero/AppHero.tsx
+++ b/ui/src/components/AppHero/AppHero.tsx
@@ -1,0 +1,43 @@
+import { VFC } from 'react'
+
+
+const AppHero: VFC = () => {
+  return (
+      <div className="bg-gray-800">
+        <div className="sm:blocksm:inset-0">
+          <div className="py-24 flex flex-col items-center justify-center">
+            <h1 className="font-bold text-4xl text-white">
+              Bet on your Beliefs
+            </h1>
+            <div className="mt-4 text-lg text-gray-400 text-center">
+              <p>Demo is a decentralized information markets platform, </p>
+              <p>
+                harnessing the power of free markets to demystify the real world
+                events that matter most to you.
+              </p>
+            </div>
+            <div className="max-w-2xl mt-12 text-sm alert shadow-lg">
+              <div>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  className="stroke-info flex-shrink-0 w-6 h-6"
+                >
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth={2}
+                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  ></path>
+                </svg>
+                <span>The markets listed here are for informational purposes only. We take no profits from them.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+  )
+}
+
+export default AppHero

--- a/ui/src/components/AppHero/index.ts
+++ b/ui/src/components/AppHero/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AppHero'

--- a/ui/src/components/MarketForm/MarketForm.tsx
+++ b/ui/src/components/MarketForm/MarketForm.tsx
@@ -2,6 +2,7 @@ import { ethers } from 'ethers'
 import { useState, VFC } from 'react'
 
 import GreeterConstruct from '~/contracts/construct/Greeter'
+import * as api from '~/services'
 
 // 型 'MetaMaskInpageProvider' の引数を型 'ExternalProvider | JsonRpcFetchFunc' のパラメーターに割り当てることはできません。
 declare let window: any
@@ -29,7 +30,8 @@ const MarketForm: VFC = () => {
       )
       await factory
         .deploy(marketTitle)
-        .then((res) => {
+        .then(async (res) => {
+          await api.postMarkets({ title: marketTitle, contract: res.address })
           setContractAddress(res.address)
         })
         .catch((err) => {

--- a/ui/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/ui/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -9,8 +9,10 @@ type DefaultLayoutProps = {
 const DefaultLayout: VFC<DefaultLayoutProps> = ({ children }) => {
   return (
     <>
-      <AppHeader />
-      <div className="container p-5 mx-auto">{children}</div>
+      <div className="border-b">
+        <AppHeader />
+      </div>
+      <div className="max-w-5xl mx-auto">{children}</div>
     </>
   )
 }

--- a/ui/src/pages/api/markets.ts
+++ b/ui/src/pages/api/markets.ts
@@ -10,12 +10,14 @@ export default async function markets(
   switch (req.method) {
     case 'POST': {
       type PostData = {
-        title: string
+        title: string,
+        contract: string,
       }
-      const { title = '' } = req.body as PostData
+      const { title = '', contract = '' } = req.body as PostData
       const result = await prisma.market.create({
         data: {
           title,
+          contract,
         },
       })
       return res.status(200).json(result)

--- a/ui/src/pages/api/markets.ts
+++ b/ui/src/pages/api/markets.ts
@@ -10,8 +10,8 @@ export default async function markets(
   switch (req.method) {
     case 'POST': {
       type PostData = {
-        title: string,
-        contract: string,
+        title: string
+        contract: string
       }
       const { title = '', contract = '' } = req.body as PostData
       const result = await prisma.market.create({

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -19,8 +19,8 @@ export default function Index({
       <ul className="grid grid-cols-3 gap-10 mt-4">
         {markets.map((market) => {
           return (
-            <Link key={market.id} href={`markets/${market.contract}`}>
-              <a className="p-5 border rounded cursor-pointer" key={market.id}>
+            <Link key={market.id} href={`/markets/${market.contract}`}>
+              <a className="p-5 border rounded cursor-pointer">
                 {market.title}
               </a>
             </Link>

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -1,11 +1,7 @@
 import type { InferGetServerSidePropsType } from 'next'
-import { useRouter } from 'next/router'
-import type { FormEvent } from 'react'
-import { useState } from 'react'
+import Link from 'next/link'
 
-import SampleCounter from '~/components/organisms/SampleCounter'
 import { prisma } from '~/lib/prisma'
-import * as api from '~/services'
 
 export const getServerSideProps = async () => {
   const markets = await prisma.market.findMany()
@@ -15,38 +11,20 @@ export const getServerSideProps = async () => {
 export default function Index({
   markets,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const router = useRouter()
-  const [marketTitle, setMarketTitle] = useState('')
-  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const res = await api.postMarkets({ title: marketTitle })
-    console.log(res)
-    router.reload() // タスク一覧の更新が面倒なのでリロードしてごまかしている
-  }
   return (
     <>
-      <div className="p-4 font-bold">Hello Tailwind CSS and daisyUI!</div>
-      <button className="btn btn-primary">Button</button>
-      <SampleCounter />
-      <hr />
-      <div className="p-5 border rounded">
-        <p>Markets</p>
-        <ul>
-          {markets.map((market) => {
-            return <li key={market.id}>・{market.title}</li>
-          })}
-        </ul>
-        <form onSubmit={handleSubmit} className="mt-5">
-          <input
-            type="text"
-            placeholder="type your market title ..."
-            className="input input-bordered input-sm mr-2"
-            value={marketTitle}
-            onChange={(e) => setMarketTitle(e.target.value)}
-          />
-          <button className="btn btn-sm">Add</button>
-        </form>
-      </div>
+      <p className="font-bold">Popular Markets</p>
+      <ul className="grid grid-cols-3 gap-10 mt-4">
+        {markets.map((market) => {
+          return (
+            <Link key={market.id} passHref={true} href={`markets/${market.contract}`}>
+              <li className="p-5 border rounded cursor-pointer" key={market.id}>
+                {market.title}
+              </li>
+            </Link>
+          )
+        })}
+      </ul>
     </>
   )
 }

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import type { InferGetServerSidePropsType } from 'next'
 import Link from 'next/link'
 
+import AppHero from '~/components/AppHero'
 import { prisma } from '~/lib/prisma'
 
 export const getServerSideProps = async () => {
@@ -13,14 +14,15 @@ export default function Index({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <>
-      <p className="font-bold">Popular Markets</p>
+      <AppHero />
+      <p className="font-bold mt-8">Popular Markets</p>
       <ul className="grid grid-cols-3 gap-10 mt-4">
         {markets.map((market) => {
           return (
-            <Link key={market.id} passHref={true} href={`markets/${market.contract}`}>
-              <li className="p-5 border rounded cursor-pointer" key={market.id}>
+            <Link key={market.id} href={`markets/${market.contract}`}>
+              <a className="p-5 border rounded cursor-pointer" key={market.id}>
                 {market.title}
-              </li>
+              </a>
             </Link>
           )
         })}

--- a/ui/src/pages/markets/[contract].tsx
+++ b/ui/src/pages/markets/[contract].tsx
@@ -1,0 +1,21 @@
+import type { GetServerSideProps,InferGetServerSidePropsType } from 'next'
+
+import { prisma } from '~/lib/prisma'
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { contract } = context.query
+  const market = await prisma.market.findFirst({
+    where: { contract: contract as string },
+  })
+  return { props: { market } }
+}
+
+export default function Index({
+  market,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <div className="mt-8">
+      <div className="p-5 border rounded">{market.title}</div>
+    </div>
+  )
+}

--- a/ui/src/pages/markets/[contract].tsx
+++ b/ui/src/pages/markets/[contract].tsx
@@ -1,4 +1,4 @@
-import type { GetServerSideProps,InferGetServerSidePropsType } from 'next'
+import type { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 
 import { prisma } from '~/lib/prisma'
 

--- a/ui/src/pages/markets/[contract].tsx
+++ b/ui/src/pages/markets/[contract].tsx
@@ -1,8 +1,16 @@
+import type { Market } from '@prisma/client'
 import type { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import ErrorPage from 'next/error'
 
 import { prisma } from '~/lib/prisma'
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+type ServerSideProps = {
+  market: Market | null
+}
+
+export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (
+  context
+) => {
   const { contract } = context.query
   const market = await prisma.market.findFirst({
     where: { contract: contract as string },
@@ -13,6 +21,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 export default function Index({
   market,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  if (!market) {
+    return <ErrorPage statusCode={404} />
+  }
+
   return (
     <div className="mt-8">
       <div className="p-5 border rounded">{market.title}</div>

--- a/ui/src/services/postMarkets.ts
+++ b/ui/src/services/postMarkets.ts
@@ -3,7 +3,8 @@ import { Market } from '@prisma/client'
 import * as request from '~/services/request'
 
 type Data = {
-  title: string
+  title: string,
+  contract: string,
 }
 
 export function postMarkets(data: Data) {

--- a/ui/src/services/postMarkets.ts
+++ b/ui/src/services/postMarkets.ts
@@ -3,8 +3,8 @@ import { Market } from '@prisma/client'
 import * as request from '~/services/request'
 
 type Data = {
-  title: string,
-  contract: string,
+  title: string
+  contract: string
 }
 
 export function postMarkets(data: Data) {


### PR DESCRIPTION
## 概要

- `markets/new` でコントラクトをデプロイした時に、タイトル・コントラクトアドレスを DB に保存
- トップ画面でマーケットの一覧を表示
- 見た目を polymarket に寄せた

<img width="1786" alt="スクリーンショット 2022-04-02 9 05 33" src="https://user-images.githubusercontent.com/8072432/161355831-0ecacbbf-bba5-48d8-aff7-c1932321ed20.png">


## 補足

多分このコマンドで migration 反映される

```sh
$ npx prisma db push --accept-data-loss
$ npx prisma migrate dev
```